### PR TITLE
Change Backgroud to PageColor

### DIFF
--- a/readme.md
+++ b/readme.md
@@ -86,7 +86,7 @@ Document.Create(container =>
     {
         page.Size(PageSizes.A4);
         page.Margin(2, Unit.Centimetre);
-        page.Background(Colors.White);
+        page.PageColor(Colors.White);
         page.DefaultTextStyle(x => x.FontSize(20));
         
         page.Header()


### PR DESCRIPTION
Using background to set color shows an obsolete warning, changed to the new PageColor instead.