### PR TITLE
Fix warning

### DIFF
--- a/InvoiceModel.cs
+++ b/InvoiceModel.cs
@@ -29,7 +29,7 @@ namespace QuestPDF.ExampleInvoice
         public string Street { get; set; }
         public string City { get; set; }
         public string State { get; set; }
-        public object Email { get; set; }
+        public string Email { get; set; }
         public string Phone { get; set; }
     }
 }


### PR DESCRIPTION
The build currently presents a warning due to an obsoleted overload on this line:
`column.Item().Text(Address.Email);`

This is due to the type of Email property being "object" instead of "string". There didn't appear to be any reason for the Email member to be object.