### PR TITLE
Use currency ("C") formatting.

### DIFF
--- a/InvoiceDocument.cs
+++ b/InvoiceDocument.cs
@@ -1,3 +1,4 @@
+using System.Globalization;
 using System.Linq;
 using QuestPDF.Drawing;
 using QuestPDF.Fluent;
@@ -45,7 +46,7 @@ namespace QuestPDF.ExampleInvoice
                     column
                         .Item().Text($"Invoice #{Model.InvoiceNumber}")
                         .FontSize(20).SemiBold().FontColor(Colors.Blue.Medium);
-                    
+
                     column.Item().Text(text =>
                     {
                         text.Span("Issue date: ").SemiBold();
@@ -79,7 +80,7 @@ namespace QuestPDF.ExampleInvoice
                 column.Item().Element(ComposeTable);
 
                 var totalPrice = Model.Items.Sum(x => x.Price * x.Quantity);
-                column.Item().PaddingRight(5).AlignRight().Text($"Grand total: {totalPrice}$").SemiBold();
+                column.Item().PaddingRight(5).AlignRight().Text($"Grand total: {totalPrice:C}").SemiBold();
 
                 if (!string.IsNullOrWhiteSpace(Model.Comments))
                     column.Item().PaddingTop(25).Element(ComposeComments);
@@ -115,12 +116,12 @@ namespace QuestPDF.ExampleInvoice
                 foreach (var item in Model.Items)
                 {
                     var index = Model.Items.IndexOf(item) + 1;
-                    
+
                     table.Cell().Element(CellStyle).Text($"{index}");
                     table.Cell().Element(CellStyle).Text(item.Name);
-                    table.Cell().Element(CellStyle).AlignRight().Text($"{item.Price}$");
+                    table.Cell().Element(CellStyle).AlignRight().Text($"{item.Price:C}");
                     table.Cell().Element(CellStyle).AlignRight().Text($"{item.Quantity}");
-                    table.Cell().Element(CellStyle).AlignRight().Text($"{item.Price * item.Quantity}$");
+                    table.Cell().Element(CellStyle).AlignRight().Text($"{item.Price * item.Quantity:C}");
                     
                     static IContainer CellStyle(IContainer container) => container.BorderBottom(1).BorderColor(Colors.Grey.Lighten2).PaddingVertical(5);
                 }


### PR DESCRIPTION
I was assessing the QuestPDF library by experimenting with this example invoice project. The documents it produces are beautiful! I did notice one thing that looks odd (to an American), the formatting for the currency amounts are incorrect. The current document will render a value as "145.6$", where in the US we'd expect that to be formatted as "$145.60": the currency symbol comes first, and we always include 2 decimal digits.

Using the "C" format has the side-effect of making the document culture-specific, so if a user is using Italian ("it-IT"), this value would render as "145,60 €" instead. That may or may not be what you intend.